### PR TITLE
Implement RFC 0050: Rename Buildpacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Paketo Buildpack for Jammyless Tiny Builder
+# Paketo Jammy Buildpackless Tiny Builder
 
 ## `paketobuildpacks/builder-jammy-buildpackless-tiny`
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Paketo Jammy Buildpackless Tiny Builder
+# Paketo Buildpack for Jammyless Tiny Builder
 
 ## `paketobuildpacks/builder-jammy-buildpackless-tiny`
 

--- a/smoke/procfile_test.go
+++ b/smoke/procfile_test.go
@@ -71,7 +71,7 @@ func testProcfile(t *testing.T, context spec.G, it spec.S) {
 
 			Eventually(container).Should(BeAvailable())
 
-			Expect(logs).To(ContainLines(ContainSubstring("Paketo Procfile Buildpack")))
+			Expect(logs).To(ContainLines(ContainSubstring("Paketo Buildpack for Procfile")))
 		})
 	})
 }


### PR DESCRIPTION
Renames 'Paketo <tech> Buildpack' to 'Paketo Buildpack for <tech>' where present in README or Go code.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this project.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
