### PR TITLE
Make the builder dual arch

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -1,5 +1,15 @@
 description = "Tiny base image (Ubuntu Jammy Jellyfish build image, distroless-like run image) with no buildpacks included. To use, specify buildpacks at build time."
 
+
+# Targets the buildpack will work with
+[[targets]]
+os = "linux"
+arch = "amd64"
+
+[[targets]]
+os = "linux"
+arch = "arm64"
+
 [lifecycle]
   version = "0.19.0"
 


### PR DESCRIPTION
first need to use `pack` exp, such as is done there: https://github.com/paketo-buildpacks/pipeline-builder-canary/blob/main/.github/workflows/pb-create-package.yml#L40

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
