### PR TITLE
fix path to experimental pack binaries

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -37,7 +37,7 @@ jobs:
         mkdir -p "${HOME}"/bin
         echo "${HOME}/bin" >> "${GITHUB_PATH}"
 
-        cp "${HOME}/experimental-pack-binaries/pack-amd64-linux" ${HOME}/bin/pack
+        cp "experimental-pack-binaries/pack-amd64-linux" ${HOME}/bin/pack
         ${HOME}/bin/pack version
 
     - name: Enable Experimental Pack Features


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Fixes error in https://github.com/paketo-buildpacks/builder-jammy-buildpackless-tiny/actions/runs/8542452024/job/23404106522

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
