### PR TITLE
Using docker registry instead of GCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ time using whatever mechanisms your CNB platform of choice offers.
 For example, with the `pack` CLI, use `--buildpack` as follows:
 ```
 pack build go-with-buildpackless-builder \
-           --buildpack gcr.io/paketo-buildpacks/go \
+           --buildpack index.docker.io/paketobuildpacks/go \
            --builder paketobuildpacks/builder-jammy-buildpackless-tiny:latest
 ```
 

--- a/smoke.json
+++ b/smoke.json
@@ -1,3 +1,3 @@
 {
-  "procfile" :  "docker://gcr.io/paketo-buildpacks/procfile"
+  "procfile" :  "docker://index.docker.io/paketobuildpacks/procfile"
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR replaces gcr registry with docker, as gcr is deprecated for usage under paketobuildpacks github org.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
